### PR TITLE
feat(server): admin endpoint network isolation and rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Admin endpoint network isolation and rate limiting (#40)
+  - `ServerBuilder::admin_port(port)` to run admin endpoints on separate localhost listener
+  - Admin endpoints (`/admin/reload`, `/admin/health`) bound to 127.0.0.1 only
+  - Rate limiting: 1 request/second on admin endpoints (returns 429 on excess)
+  - Public router excludes admin routes when admin_port is configured
+  - CLI: `inspire-server config.json 3000 3001` runs public on :3000, admin on 127.0.0.1:3001
+  - Backwards compatible: omit admin_port for combined single-listener mode
+
 - `burner-wallet` crate: Axum+Askama server-rendered wallet UI (#35)
   - Full Rust/WASM stack (no React/Next.js)
   - Generate/import burner wallet with localStorage persistence

--- a/crates/inspire-server/Cargo.toml
+++ b/crates/inspire-server/Cargo.toml
@@ -21,3 +21,4 @@ tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 arc-swap = { workspace = true }
+tower = { version = "0.5", features = ["limit"] }

--- a/crates/inspire-server/src/routes.rs
+++ b/crates/inspire-server/src/routes.rs
@@ -205,7 +205,28 @@ fn parse_lane(s: &str) -> Result<Lane> {
     }
 }
 
-/// Create the router with all routes
+/// Create the public router (exposed to the internet)
+pub fn create_public_router(state: SharedState) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/info", get(info))
+        .route("/crs/{lane}", get(get_crs))
+        .route("/query/{lane}", post(query))
+        .route("/query/{lane}/binary", post(query_binary))
+        .route("/query/{lane}/seeded", post(query_seeded))
+        .route("/query/{lane}/seeded/binary", post(query_seeded_binary))
+        .with_state(state)
+}
+
+/// Create the admin router (bound to localhost only)
+pub fn create_admin_router(state: SharedState) -> Router {
+    Router::new()
+        .route("/admin/reload", post(admin_reload))
+        .route("/admin/health", get(health))
+        .with_state(state)
+}
+
+/// Create combined router (for backwards compatibility / testing)
 pub fn create_router(state: SharedState) -> Router {
     Router::new()
         .route("/health", get(health))

--- a/crates/inspire-server/src/server.rs
+++ b/crates/inspire-server/src/server.rs
@@ -1,25 +1,81 @@
 //! Two-lane PIR server implementation
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+};
 use inspire_core::TwoLaneConfig;
 use tokio::net::TcpListener;
 
 use crate::error::Result;
-use crate::routes::create_router;
+use crate::routes::{create_admin_router, create_public_router, create_router};
 use crate::state::{create_shared_state, SharedState};
+
+/// Rate limiter state for admin endpoints
+#[derive(Clone)]
+struct RateLimiter {
+    last_request: Arc<AtomicU64>,
+    min_interval: Duration,
+}
+
+impl RateLimiter {
+    fn new(min_interval: Duration) -> Self {
+        Self {
+            last_request: Arc::new(AtomicU64::new(0)),
+            min_interval,
+        }
+    }
+
+    fn check(&self) -> bool {
+        let now = Instant::now().elapsed().as_millis() as u64;
+        let last = self.last_request.load(Ordering::Relaxed);
+        let min_ms = self.min_interval.as_millis() as u64;
+        
+        if now.saturating_sub(last) >= min_ms {
+            self.last_request.store(now, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+async fn rate_limit_middleware(
+    State(limiter): State<RateLimiter>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    if !limiter.check() {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "Rate limit exceeded. Try again in 1 second.",
+        )
+            .into_response();
+    }
+    next.run(request).await
+}
+
+use axum::extract::State;
 
 /// Two-lane PIR server
 pub struct TwoLaneServer {
     state: SharedState,
-    addr: SocketAddr,
+    public_addr: SocketAddr,
+    admin_addr: Option<SocketAddr>,
 }
 
 impl TwoLaneServer {
     /// Create a new server with the given configuration
-    pub fn new(config: TwoLaneConfig, addr: SocketAddr) -> Self {
+    pub fn new(config: TwoLaneConfig, public_addr: SocketAddr, admin_addr: Option<SocketAddr>) -> Self {
         let state = create_shared_state(config);
-        Self { state, addr }
+        Self { state, public_addr, admin_addr }
     }
 
     /// Load both lanes from disk
@@ -27,16 +83,63 @@ impl TwoLaneServer {
         self.state.load_lanes()
     }
 
-    /// Run the server
+    /// Run the server (single listener mode for backwards compatibility)
     pub async fn run(self) -> Result<()> {
+        if self.admin_addr.is_some() {
+            self.run_dual().await
+        } else {
+            self.run_combined().await
+        }
+    }
+
+    /// Run with combined router (backwards compatible)
+    async fn run_combined(self) -> Result<()> {
         let router = create_router(self.state);
 
-        tracing::info!("Starting Two-Lane PIR server on {}", self.addr);
+        tracing::info!("Starting Two-Lane PIR server on {}", self.public_addr);
 
-        let listener = TcpListener::bind(self.addr).await?;
+        let listener = TcpListener::bind(self.public_addr).await?;
         axum::serve(listener, router)
             .await
             .map_err(|e| crate::error::ServerError::Internal(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Run with separate public and admin listeners
+    async fn run_dual(self) -> Result<()> {
+        let admin_addr = self.admin_addr.expect("admin_addr required for dual mode");
+        
+        let public_router = create_public_router(self.state.clone());
+        
+        let rate_limiter = RateLimiter::new(Duration::from_secs(1));
+        let admin_router = create_admin_router(self.state.clone())
+            .layer(middleware::from_fn_with_state(rate_limiter, rate_limit_middleware));
+
+        tracing::info!("Starting public PIR server on {}", self.public_addr);
+        tracing::info!("Starting admin server on {} (localhost only)", admin_addr);
+
+        let public_listener = TcpListener::bind(self.public_addr).await?;
+        let admin_listener = TcpListener::bind(admin_addr).await?;
+
+        let public_handle = tokio::spawn(async move {
+            axum::serve(public_listener, public_router).await
+        });
+
+        let admin_handle = tokio::spawn(async move {
+            axum::serve(admin_listener, admin_router).await
+        });
+
+        tokio::select! {
+            res = public_handle => {
+                res.map_err(|e| crate::error::ServerError::Internal(e.to_string()))?
+                   .map_err(|e| crate::error::ServerError::Internal(e.to_string()))?;
+            }
+            res = admin_handle => {
+                res.map_err(|e| crate::error::ServerError::Internal(e.to_string()))?
+                   .map_err(|e| crate::error::ServerError::Internal(e.to_string()))?;
+            }
+        }
 
         Ok(())
     }
@@ -50,7 +153,8 @@ impl TwoLaneServer {
 /// Builder for TwoLaneServer
 pub struct ServerBuilder {
     config: TwoLaneConfig,
-    addr: SocketAddr,
+    public_addr: SocketAddr,
+    admin_addr: Option<SocketAddr>,
     load_lanes: bool,
 }
 
@@ -58,22 +162,30 @@ impl ServerBuilder {
     pub fn new(config: TwoLaneConfig) -> Self {
         Self {
             config,
-            addr: ([127, 0, 0, 1], 3000).into(),
+            public_addr: ([127, 0, 0, 1], 3000).into(),
+            admin_addr: None,
             load_lanes: true,
         }
     }
 
     pub fn addr(mut self, addr: SocketAddr) -> Self {
-        self.addr = addr;
+        self.public_addr = addr;
         self
     }
 
     pub fn port(mut self, port: u16) -> Self {
-        self.addr = ([0, 0, 0, 0], port).into();
+        self.public_addr = ([0, 0, 0, 0], port).into();
         self
     }
 
-
+    /// Set admin port (binds to 127.0.0.1 only for security)
+    /// 
+    /// When set, admin endpoints (/admin/*) are served on a separate
+    /// listener bound to localhost, providing network isolation.
+    pub fn admin_port(mut self, port: u16) -> Self {
+        self.admin_addr = Some(([127, 0, 0, 1], port).into());
+        self
+    }
 
     /// Skip loading lanes on build (useful for testing)
     pub fn skip_load(mut self) -> Self {
@@ -82,7 +194,7 @@ impl ServerBuilder {
     }
 
     pub fn build(self) -> Result<TwoLaneServer> {
-        let server = TwoLaneServer::new(self.config, self.addr);
+        let server = TwoLaneServer::new(self.config, self.public_addr, self.admin_addr);
 
         if self.load_lanes {
             server.load_lanes()?;


### PR DESCRIPTION
## Summary

Implements network isolation and rate limiting for admin endpoints as specified in issue #40.

## Changes

### Network Isolation
- Split router into `create_public_router()` and `create_admin_router()`
- Admin endpoints (`/admin/reload`, `/admin/health`) served on separate listener bound to `127.0.0.1` only
- Public router no longer includes admin routes when admin_port is configured

### Rate Limiting
- 1 request/second limit on admin endpoints
- Returns `429 Too Many Requests` when exceeded
- Simple atomic timestamp-based limiter (no external dependencies)

### API
- `ServerBuilder::admin_port(port)` - enables dual-listener mode
- CLI: `inspire-server config.json 3000 3001` runs public on :3000, admin on 127.0.0.1:3001
- Backwards compatible: omit admin_port for combined single-listener mode (existing behavior)

## Security Benefits
- External attackers cannot access `/admin/reload` (network-level isolation)
- Even localhost attackers limited to 1 reload/sec (prevents DoS via reload spam)

## Usage

```bash
# Production mode: admin isolated on localhost:3001
inspire-server config.json 3000 3001

# Development mode: combined (backwards compatible)
inspire-server config.json 3000
```

Closes #40

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separate localhost-bound admin listener with 1 rps rate limit; public router excludes admin routes and CLI/ServerBuilder gain admin_port.
> 
> - **Server/Runtime**
>   - Dual-listener mode: public on `0.0.0.0:{port}` and admin on `127.0.0.1:{admin_port}` with `TwoLaneServer::run_dual()`.
>   - Atomic timestamp-based rate limiter (1 req/sec) applied to admin routes; returns `429` when exceeded.
>   - Backwards-compatible combined mode retained via `create_router()`.
> - **Routing**
>   - Split routers: `create_public_router(state)` (no admin routes) and `create_admin_router(state)` (`/admin/reload`, `/admin/health`).
> - **Builder/CLI**
>   - `ServerBuilder::admin_port(port)` to enable dual-listener mode; `port()` continues to set public bind address.
>   - CLI now accepts optional `admin_port` arg (`inspire-server [config.json] [port] [admin_port]`).
> - **Misc**
>   - Updated logs and CHANGELOG to reflect admin isolation and rate limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1649fd2dbc95861db5aa7ff585c27f87c88c7e43. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable separate admin endpoints with network isolation (bound to localhost) for enhanced security.
  * Introduced per-endpoint rate limiting on admin routes.
  * Added optional admin_port CLI argument to configure a dedicated admin listener.
  * Maintained backwards compatibility when admin_port is not specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->