### PR TITLE
feat: use tree packing to reduce response size (544KB → 32KB)

### DIFF
--- a/crates/inspire-client-wasm/src/client.rs
+++ b/crates/inspire-client-wasm/src/client.rs
@@ -6,11 +6,11 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use inspire_pir::{
-    query_seeded as pir_query_seeded, extract,
+    query_seeded as pir_query_seeded, extract_with_variant,
     SeededClientQuery, ServerCrs, ServerResponse,
 };
 use inspire_pir::math::GaussianSampler;
-use inspire_pir::params::ShardConfig;
+use inspire_pir::params::{InspireVariant, ShardConfig};
 use inspire_core::PIR_PARAMS_VERSION;
 
 use crate::console_log;
@@ -148,11 +148,12 @@ impl PirClient {
         
         console_log!("Extracting result...");
         
-        let entry = extract(
+        let entry = extract_with_variant(
             &inner.crs,
             &client_state,
             &response.response,
             64,
+            InspireVariant::OnePacking,
         ).map_err(|e| PirError::Pir(e.to_string()))?;
         
         Ok(entry)
@@ -183,11 +184,12 @@ impl PirClient {
         let response = ServerResponse::from_binary(&bytes)
             .map_err(|e| PirError::Pir(e.to_string()))?;
         
-        let entry = extract(
+        let entry = extract_with_variant(
             &inner.crs,
             &client_state,
             &response,
             64,
+            InspireVariant::OnePacking,
         ).map_err(|e| PirError::Pir(e.to_string()))?;
         
         Ok(entry)

--- a/crates/inspire-client/src/client.rs
+++ b/crates/inspire-client/src/client.rs
@@ -6,9 +6,10 @@ use serde::{Deserialize, Serialize};
 use inspire_core::{Address, Lane, LaneRouter, StorageKey, StorageValue};
 use inspire_pir::{
     ServerCrs, ClientQuery, ClientState, SeededClientQuery, ServerResponse,
-    query as pir_query, query_seeded as pir_query_seeded, extract,
+    query as pir_query, query_seeded as pir_query_seeded, extract_with_variant,
     InspireParams,
 };
+use inspire_pir::params::InspireVariant;
 use inspire_pir::math::GaussianSampler;
 use inspire_pir::rlwe::RlweSecretKey;
 
@@ -185,11 +186,12 @@ impl TwoLaneClient {
             }
         };
         
-        let entry = extract(
+        let entry = extract_with_variant(
             &lane_state.crs,
             &client_state,
             &server_response,
             32,
+            InspireVariant::OnePacking,
         ).map_err(|e| ClientError::InvalidResponse(e.to_string()))?;
         
         let mut result = [0u8; 32];


### PR DESCRIPTION
## Summary

Update to match inspire-rs tree packing changes. Reduces HTTP response size from **544 KB to 32 KB** (17x reduction).

## Changes

### Server (`inspire-server/src/state.rs`)
- `respond()` → `respond_one_packing()`
- `respond_mmap()` → `respond_mmap_one_packing()`

### Native Client (`inspire-client/src/client.rs`)
- `extract()` → `extract_with_variant(..., InspireVariant::OnePacking)`

### WASM Client (`inspire-client-wasm/src/client.rs`)
- Same changes for browser client

## Dependency

Requires igor53627/inspire-rs#29 to be merged first.

## Communication Cost Impact

| Component | Before | After |
|-----------|--------|-------|
| Response | 544 KB | 32 KB |
| Total per query | ~640 KB | ~128 KB |

## Testing
```bash
cargo check
cargo test
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch server to `respond_*_one_packing` and clients to `extract_with_variant(..., InspireVariant::OnePacking)`, reducing PIR response size from ~544 KB to ~32 KB.
> 
> - **Backend**:
>   - Use `respond_one_packing`/`respond_mmap_one_packing` in `crates/inspire-server/src/state.rs::LaneData::process_query` to enable tree packing.
> - **Clients**:
>   - **Native (`crates/inspire-client/src/client.rs`)**: Replace `extract` with `extract_with_variant(..., InspireVariant::OnePacking)` when parsing `ServerResponse`.
>   - **WASM (`crates/inspire-client-wasm/src/client.rs`)**: Same extraction change in both `query` and `query_binary`; import `InspireVariant`.
> - **Effect**:
>   - Tree packing (`OnePacking`) reduces PIR response payloads to ~32 KB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 274ac305a522013be30748ffbe20b1484e007795. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized server response handling with improved packing strategy to reduce response sizes.

* **Refactor**
  * Updated internal data extraction mechanisms for more efficient and consistent processing across client and server components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->