### PR TITLE
feat(inspire-server): use InspiRING packing when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **inspire-server**: Use InspiRING packing (~35x faster) when packing keys available in query, otherwise tree packing
 - **BREAKING**: `getBalance()` now throws `AddressNotFoundError` when address is not in PIR database (#49)
   - Previously returned zero balances, which was semantically incorrect
   - Use `getBalanceWithFallback()` for the "always returns a result" behavior


### PR DESCRIPTION
## Summary

Use InspiRING packing algorithm (~35x faster online) in inspire-server when `inspiring_packing_keys` is present in the query.

### Changes

- **LaneData::process_query**: Uses InspiRING when packing keys available, falls back to tree packing
- For mmap databases, still uses tree packing (TODO: add `respond_mmap_inspiring` when needed)

### Dependencies

Requires https://github.com/igor53627/inspire-rs/pull/30 which exports the necessary functions.

### Performance

- InspiRING online: ~115 μs (for d=2048, 16 LWEs)
- Tree packing: ~4 ms
- **~35x faster** when packing keys are included in query

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `LaneData::process_query` to use InspiRING packing when `inspiring_packing_keys` are present, otherwise use tree packing; mmap path remains tree packing.
> 
> - **Backend (inspire-server)**:
>   - `LaneData::process_query()` now selects packing:
>     - Uses `respond_inspiring()` when `query.inspiring_packing_keys` is present (faster path).
>     - Falls back to `respond_one_packing()`; mmap path continues with `respond_mmap_one_packing()`.
>   - Imports updated to include `respond_inspiring`.
> - **Docs**:
>   - `CHANGELOG.md`: Notes new InspiRING packing behavior and fallback strategy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45be41cc4dbe3d8850f24e51a1c3c29663c7a977. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Query processing for in-memory databases now intelligently adapts its packing strategy based on available data characteristics. When certain data parameters are present, the system applies an optimized approach; otherwise it defaults to the standard strategy, improving performance across different scenarios.
  * Memory-mapped storage paths remain unchanged with optimization planned for future releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->