### PR TITLE
Add IPC/UBT updater flow and architecture docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Alloy for RPC access (gas backfill) - must match reth v1.9.3's alloy version
 alloy-provider = { version = "1.1", features = ["reqwest"] }
+alloy-rpc-client = { version = "1.1", features = ["reqwest", "ipc"] }
 alloy-rpc-types = "1.1"
 alloy-primitives = "1.5"
 alloy-transport = "1.1"

--- a/crates/inspire-updater/Cargo.toml
+++ b/crates/inspire-updater/Cargo.toml
@@ -10,10 +10,9 @@ path = "src/bin/updater.rs"
 [dependencies]
 clap = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-alloy-provider = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-rpc-client = { workspace = true }
 alloy-rpc-types = { workspace = true }
-alloy-transport = { workspace = true }
 tokio = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/crates/inspire-updater/src/config.rs
+++ b/crates/inspire-updater/src/config.rs
@@ -7,6 +7,8 @@ pub struct UpdaterConfig {
     pub rpc_url: String,
     /// ethrex admin RPC (pir_* methods) - optional, fallback to rpc_url
     pub admin_rpc_url: Option<String>,
+    /// ubt-exex RPC (ubt_* methods) - optional, enables UBT export mode
+    pub ubt_rpc_url: Option<String>,
     /// PIR server URL for reload
     pub pir_server_url: String,
     /// Directory to write PIR data
@@ -17,6 +19,8 @@ pub struct UpdaterConfig {
     pub max_blocks_per_fetch: u64,
     /// Ethereum chain ID (1=mainnet, 11155111=sepolia)
     pub chain_id: u64,
+    /// Run a single initial sync and exit
+    pub one_shot: bool,
 }
 
 impl Default for UpdaterConfig {
@@ -24,11 +28,13 @@ impl Default for UpdaterConfig {
         Self {
             rpc_url: "http://localhost:8545".into(),
             admin_rpc_url: None,
+            ubt_rpc_url: None,
             pir_server_url: "http://localhost:3000".into(),
             data_dir: PathBuf::from("./pir-data"),
             poll_interval: Duration::from_secs(1),
             max_blocks_per_fetch: 100,
             chain_id: 11155111, // Sepolia
+            one_shot: false,
         }
     }
 }

--- a/crates/inspire-updater/src/lib.rs
+++ b/crates/inspire-updater/src/lib.rs
@@ -29,8 +29,8 @@ mod writer;
 pub use config::UpdaterConfig;
 pub use delta_writer::RangeDeltaWriter;
 pub use rpc::{
-    BlockDeltas, DumpStorageResponse, EthrexClient, StateDeltaResponse, StorageEntry,
-    UbtRootResponse,
+    BlockDeltas, DumpStorageResponse, EthrexClient, StateDeltaResponse, StateRpcMode, StorageEntry,
+    UbtExportStateResult, UbtRootResponse, UbtStateDeltaResult,
 };
 pub use service::{ReloadClient, UpdaterService};
 pub use state::StateTracker;

--- a/crates/inspire-updater/src/rpc.rs
+++ b/crates/inspire-updater/src/rpc.rs
@@ -1,7 +1,8 @@
-use alloy_primitives::{Address, B256, U256};
-use alloy_provider::{Provider, ProviderBuilder};
+use alloy_primitives::{Address, B256, U256, U64};
+use alloy_rpc_client::{ClientBuilder, RpcClient};
 use alloy_rpc_types::BlockNumberOrTag;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::path::Path;
 
 /// Storage entry from pir_dumpStorage
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,6 +27,14 @@ pub struct UbtRootResponse {
     pub root: B256,
 }
 
+/// Response from ubt_getRoot (ubt-exex format)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UbtRootResult {
+    #[serde(rename = "blockNumber")]
+    pub block_number: u64,
+    pub root: B256,
+}
+
 /// Block deltas from pir_getStateDelta
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockDeltas {
@@ -42,62 +51,140 @@ pub struct StateDeltaResponse {
     pub total_deltas: u64,
 }
 
+/// Params for ubt_exportState
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UbtExportStateParams {
+    pub output_path: String,
+    #[serde(default)]
+    pub chain_id: Option<u64>,
+}
+
+/// Result from ubt_exportState
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UbtExportStateResult {
+    #[serde(rename = "blockNumber")]
+    pub block_number: u64,
+    #[serde(rename = "blockHash")]
+    pub block_hash: B256,
+    pub root: B256,
+    #[serde(rename = "entryCount")]
+    pub entry_count: u64,
+    #[serde(rename = "stemCount")]
+    pub stem_count: u64,
+    #[serde(rename = "stateFile")]
+    pub state_file: String,
+    #[serde(rename = "stemIndexFile")]
+    pub stem_index_file: String,
+}
+
+/// Params for ubt_getStateDelta
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UbtStateDeltaParams {
+    pub from_block: u64,
+    pub to_block: u64,
+    pub output_path: String,
+    #[serde(default)]
+    pub chain_id: Option<u64>,
+}
+
+/// Result from ubt_getStateDelta
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UbtStateDeltaResult {
+    #[serde(rename = "fromBlock")]
+    pub from_block: u64,
+    #[serde(rename = "toBlock")]
+    pub to_block: u64,
+    #[serde(rename = "headBlock")]
+    pub head_block: u64,
+    #[serde(rename = "entryCount")]
+    pub entry_count: u64,
+    #[serde(rename = "deltaFile")]
+    pub delta_file: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateRpcMode {
+    LegacyPir,
+    UbtExex,
+}
+
 /// Client for ethrex RPC
 pub struct EthrexClient {
-    rpc_url: String,
-    http: reqwest::Client,
+    chain: RpcClient,
+    state: RpcClient,
+    state_mode: StateRpcMode,
 }
 
 impl EthrexClient {
-    pub async fn new(rpc_url: &str, _admin_url: Option<String>) -> anyhow::Result<Self> {
-        let provider = ProviderBuilder::new().connect(rpc_url).await?;
-        let _ = provider.get_block_number().await?;
+    pub async fn new(
+        rpc_url: &str,
+        admin_url: Option<String>,
+        ubt_rpc_url: Option<String>,
+    ) -> anyhow::Result<Self> {
+        let chain = ClientBuilder::default().connect(rpc_url).await?;
+
+        let (state_url, state_mode) = if let Some(url) = ubt_rpc_url {
+            (url, StateRpcMode::UbtExex)
+        } else if let Some(url) = admin_url {
+            (url, StateRpcMode::LegacyPir)
+        } else {
+            (rpc_url.to_string(), StateRpcMode::LegacyPir)
+        };
+
+        let state = if state_url == rpc_url {
+            chain.clone()
+        } else {
+            ClientBuilder::default().connect(&state_url).await?
+        };
+
         Ok(Self {
-            rpc_url: rpc_url.to_string(),
-            http: reqwest::Client::new(),
+            chain,
+            state,
+            state_mode,
         })
     }
 
-    async fn provider(&self) -> anyhow::Result<impl Provider> {
-        Ok(ProviderBuilder::new().connect(&self.rpc_url).await?)
+    pub fn state_mode(&self) -> StateRpcMode {
+        self.state_mode
     }
 
     /// Raw JSON-RPC call
-    async fn rpc_call<T: for<'de> Deserialize<'de>>(
+    async fn rpc_call_state<Params, Resp>(
         &self,
         method: &str,
-        params: serde_json::Value,
-    ) -> anyhow::Result<T> {
-        let body = serde_json::json!({
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params,
-            "id": 1
-        });
+        params: Params,
+    ) -> anyhow::Result<Resp>
+    where
+        Params: Serialize + Clone + std::fmt::Debug + Send + Sync + Unpin + 'static,
+        Resp: DeserializeOwned + std::fmt::Debug + Send + Sync + Unpin + 'static,
+    {
+        Ok(self.state.request(method.to_string(), params).await?)
+    }
 
-        let resp = self
-            .http
-            .post(&self.rpc_url)
-            .json(&body)
-            .send()
-            .await?
-            .json::<serde_json::Value>()
-            .await?;
-
-        if let Some(error) = resp.get("error") {
-            anyhow::bail!("RPC error: {}", error);
-        }
-
-        let result = resp
-            .get("result")
-            .ok_or_else(|| anyhow::anyhow!("Missing result in RPC response"))?;
-
-        Ok(serde_json::from_value(result.clone())?)
+    async fn rpc_call_chain<Params, Resp>(
+        &self,
+        method: &str,
+        params: Params,
+    ) -> anyhow::Result<Resp>
+    where
+        Params: Serialize + Clone + std::fmt::Debug + Send + Sync + Unpin + 'static,
+        Resp: DeserializeOwned + std::fmt::Debug + Send + Sync + Unpin + 'static,
+    {
+        Ok(self.chain.request(method.to_string(), params).await?)
     }
 
     /// Get current block number
     pub async fn block_number(&self) -> anyhow::Result<u64> {
-        Ok(self.provider().await?.get_block_number().await?)
+        let block: U64 = self.chain.request_noparams("eth_blockNumber").await?;
+        Ok(block.to::<u64>())
+    }
+
+    /// Get head block number (ubt_getRoot for ubt-exex mode)
+    pub async fn head_block(&self) -> anyhow::Result<u64> {
+        match self.state_mode {
+            StateRpcMode::LegacyPir => self.block_number().await,
+            StateRpcMode::UbtExex => Ok(self.ubt_get_root(0).await?.block_number),
+        }
     }
 
     /// Get storage at specific slot
@@ -108,23 +195,30 @@ impl EthrexClient {
         block: BlockNumberOrTag,
     ) -> anyhow::Result<U256> {
         Ok(self
-            .provider()
-            .await?
-            .get_storage_at(address, slot.into())
-            .block_id(block.into())
+            .rpc_call_chain("eth_getStorageAt", (address, slot, block))
             .await?)
     }
 
     /// Get UBT root hash for block (public endpoint)
     /// Note: ubt_getRoot returns just the root hash as a hex string
     pub async fn ubt_get_root(&self, block: u64) -> anyhow::Result<UbtRootResponse> {
-        let root: B256 = self
-            .rpc_call("ubt_getRoot", serde_json::json!([block]))
-            .await?;
-        Ok(UbtRootResponse {
-            block_number: block,
-            root,
-        })
+        match self.state_mode {
+            StateRpcMode::LegacyPir => {
+                let root: B256 = self.rpc_call_state("ubt_getRoot", (block,)).await?;
+                Ok(UbtRootResponse {
+                    block_number: block,
+                    root,
+                })
+            }
+            StateRpcMode::UbtExex => {
+                let result: UbtRootResult =
+                    self.state.request_noparams("ubt_getRoot").await?;
+                Ok(UbtRootResponse {
+                    block_number: result.block_number,
+                    root: result.root,
+                })
+            }
+        }
     }
 
     /// Dump storage with pagination
@@ -135,8 +229,11 @@ impl EthrexClient {
         cursor: Option<&str>,
         limit: u64,
     ) -> anyhow::Result<DumpStorageResponse> {
-        self.rpc_call("pir_dumpStorage", serde_json::json!([cursor, limit]))
-            .await
+        if self.state_mode == StateRpcMode::UbtExex {
+            anyhow::bail!("pir_dumpStorage is not available in ubt-exex mode");
+        }
+        let cursor = cursor.map(|value| value.to_string());
+        self.rpc_call_state("pir_dumpStorage", (cursor, limit)).await
     }
 
     /// Get state deltas for block range (max 100 blocks)
@@ -145,11 +242,47 @@ impl EthrexClient {
         from_block: u64,
         to_block: u64,
     ) -> anyhow::Result<StateDeltaResponse> {
-        self.rpc_call(
-            "pir_getStateDelta",
-            serde_json::json!([from_block, to_block]),
-        )
-        .await
+        if self.state_mode == StateRpcMode::UbtExex {
+            anyhow::bail!("pir_getStateDelta is not available in ubt-exex mode");
+        }
+        self.rpc_call_state("pir_getStateDelta", (from_block, to_block))
+            .await
+    }
+
+    /// Export full UBT state via ubt-exex (writes state.bin + stem_index.bin)
+    pub async fn ubt_export_state(
+        &self,
+        output_dir: &Path,
+        chain_id: u64,
+    ) -> anyhow::Result<UbtExportStateResult> {
+        if self.state_mode != StateRpcMode::UbtExex {
+            anyhow::bail!("ubt_exportState requires ubt-exex mode");
+        }
+        let params = UbtExportStateParams {
+            output_path: output_dir.display().to_string(),
+            chain_id: Some(chain_id),
+        };
+        self.rpc_call_state("ubt_exportState", (params,)).await
+    }
+
+    /// Export state deltas via ubt-exex (writes delta file)
+    pub async fn ubt_get_state_delta(
+        &self,
+        from_block: u64,
+        to_block: u64,
+        output_dir: &Path,
+        chain_id: u64,
+    ) -> anyhow::Result<UbtStateDeltaResult> {
+        if self.state_mode != StateRpcMode::UbtExex {
+            anyhow::bail!("ubt_getStateDelta requires ubt-exex mode");
+        }
+        let params = UbtStateDeltaParams {
+            from_block,
+            to_block,
+            output_path: output_dir.display().to_string(),
+            chain_id: Some(chain_id),
+        };
+        self.rpc_call_state("ubt_getStateDelta", (params,)).await
     }
 
     /// Iterate all storage entries
@@ -159,6 +292,9 @@ impl EthrexClient {
         limit_per_page: u64,
         mut on_page: impl FnMut(usize, &[StorageEntry]),
     ) -> anyhow::Result<Vec<StorageEntry>> {
+        if self.state_mode == StateRpcMode::UbtExex {
+            anyhow::bail!("dump_all_storage is not available in ubt-exex mode");
+        }
         let mut all_entries = Vec::new();
         let mut cursor: Option<String> = None;
         let mut page = 0;

--- a/crates/inspire-updater/src/state.rs
+++ b/crates/inspire-updater/src/state.rs
@@ -28,6 +28,10 @@ impl StateTracker {
         self.last_block
     }
 
+    pub fn set_last_block(&mut self, block: u64) {
+        self.last_block = Some(block);
+    }
+
     /// Apply entries and return ones that changed
     pub fn apply_entries(&mut self, block: u64, entries: Vec<StorageEntry>) -> Vec<StorageEntry> {
         let mut changed = Vec::new();

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,61 @@
+# Architecture
+
+This document summarizes the current end-to-end architecture and data flow for
+the UBT → PIR pipeline.
+
+## Overview
+
+The system keeps Ethereum state in **UBT (EIP-7864)** order and serves PIR
+queries over a single-server InsPIRe database. Clients compute a deterministic
+index from `(address, storage slot)` and do not need a manifest download.
+
+### Data stores (ubt-exex)
+
+- **NOMT**: authoritative values (per 32-byte `tree_index`)
+- **key-index.redb**: authoritative key enumeration and metadata
+  - `stem -> {address, bitmap(256)}` for key enumeration
+  - `head` metadata: block number, block hash, root, stem count
+- **MDBX**: retained for deltas/reorg history (not used for snapshot export)
+
+The export path uses **NOMT for values** and **key-index.redb for enumeration**.
+MDBX is not required to build `state.bin`.
+
+## End-to-end flow
+
+```
+reth
+  └── ubt-exex (ExEx)
+       ├── NOMT (values)
+       ├── key-index.redb (keys + head metadata)
+       └── MDBX (deltas only)
+
+ubt_exportState (RPC)
+  └── state.bin + stem-index.bin
+        └── state-to-pir
+             └── PIR DB + CRS + config
+                  └── inspire-server
+                       └── inspire-client / wasm
+```
+
+## Key index details
+
+The key index stores one record per stem:
+
+```
+key:   stem (31 bytes)
+value: address (20 bytes) || bitmap (32 bytes)
+```
+
+`bitmap` marks which subindices (0–255) are present in that stem. This is
+enough to enumerate the full UBT keyspace without MDBX.
+
+The `head` metadata is stored in the same redb file and is used for
+`ubt_getRoot` and snapshot metadata.
+
+## Snapshot export
+
+`ubt_exportState` writes:
+
+- `state.bin` — PIR2 format records (address, tree_index, value) in UBT order
+- `stem-index.bin` — stem → first offset mapping
+

--- a/docs/LIVE_UPDATES.md
+++ b/docs/LIVE_UPDATES.md
@@ -2,6 +2,8 @@
 
 The server supports hot-reloading lane databases without restart or query interruption.
 
+See `docs/ARCHITECTURE.md` for the broader pipeline context.
+
 ## Architecture
 
 ```

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -5,6 +5,8 @@ state queries, as implemented in [`inspire-rs`] and extended by `inspire-exex`.
 
 [`inspire-rs`]: https://github.com/igor53627/inspire-rs
 
+See `docs/ARCHITECTURE.md` for the current end-to-end data flow and storage layout.
+
 ## Version Note
 
 > **Initial Version**: The initial implementation uses a **single lane**

--- a/docs/STATE_FORMAT.md
+++ b/docs/STATE_FORMAT.md
@@ -2,6 +2,8 @@
 
 This document specifies the `state.bin` format for PIR database generation.
 
+See `docs/ARCHITECTURE.md` for the end-to-end pipeline that produces this file.
+
 ## Format Overview
 
 ```


### PR DESCRIPTION
## Summary
- add IPC/HTTP support in inspire-updater with UBT mode (export + head), plus one-shot sync
- wire updater service to UBT RPC and expose head block helpers
- document NOMT + key-index + PIR pipeline in README and new ARCHITECTURE.md

## Testing
- cargo check -p inspire-updater

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes the pipeline to use `reth + ubt-exex` and adds an IPC-capable updater with UBT-aware syncing.
> 
> - Switch RPC layer to `alloy-rpc-client` and add `ipc` support; introduce `StateRpcMode` with legacy `pir_*` and new UBT (`ubt_*`) paths
> - Updater CLI/service: new `--ubt-rpc-url` (IPC/HTTP), `--one-shot`; add `head_block()`; initial sync via `ubt_exportState` and incremental updates via `ubt_getStateDelta` with server hot-reload; retain legacy `pir_dumpStorage`/`pir_getStateDelta` fallback
> - Config/state: add `ubt_rpc_url`, `one_shot`, and `set_last_block`; service logs mode and verifies UBT root at head
> - README: replace ethrex exporter with `ubt-exex` flow; update usage commands and index computation text; point to detailed docs
> - Docs: add `docs/ARCHITECTURE.md`; update cross-references in `LIVE_UPDATES.md`, `PROTOCOL.md`, and `STATE_FORMAT.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea8797a000fd8cd70d31f48381a5817f6f973c2a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->