### PR TITLE
Use TwoPacking (seeded) and drop switched CLI paths

### DIFF
--- a/crates/burner-wallet/src/bin/pir_mock_server.rs
+++ b/crates/burner-wallet/src/bin/pir_mock_server.rs
@@ -99,6 +99,7 @@ fn test_params() -> InspireParams {
     InspireParams {
         ring_dim: 256,
         q: 1152921504606830593,
+        crt_moduli: vec![1152921504606830593],
         p: 65537, // Fermat prime F4, ensures gcd(d, p) = 1 for mod_inverse
         sigma: 6.4,
         gadget_base: 1 << 20,

--- a/crates/inspire-client-wasm/src/client.rs
+++ b/crates/inspire-client-wasm/src/client.rs
@@ -207,7 +207,7 @@ impl PirClient {
             &client_state,
             &response.response,
             64,
-            InspireVariant::OnePacking,
+            InspireVariant::TwoPacking,
         )
         .map_err(|e| PirError::Pir(e.to_string()))?;
 
@@ -251,7 +251,7 @@ impl PirClient {
             &client_state,
             &response,
             inner.shard_config.entry_size_bytes,
-            InspireVariant::OnePacking,
+            InspireVariant::TwoPacking,
         )
         .map_err(|e| PirError::Pir(e.to_string()))?;
 

--- a/crates/inspire-client/src/bin/main.rs
+++ b/crates/inspire-client/src/bin/main.rs
@@ -13,9 +13,9 @@ async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 3 {
-        eprintln!("Usage: {} <server_url> <contract_address> [slot] [--switched]", args[0]);
+        eprintln!("Usage: {} <server_url> <contract_address> [slot]", args[0]);
         eprintln!(
-            "Example: {} http://localhost:3000 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 0x00 --switched",
+            "Example: {} http://localhost:3000 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 0x00",
             args[0]
         );
         std::process::exit(1);
@@ -24,13 +24,8 @@ async fn main() -> anyhow::Result<()> {
     let server_url = &args[1];
     let contract_hex = &args[2];
     let mut slot_hex = "0x00";
-    let mut use_switched = false;
     for arg in args.iter().skip(3) {
-        if arg == "--switched" {
-            use_switched = true;
-        } else {
-            slot_hex = arg;
-        }
+        slot_hex = arg;
     }
 
     let contract = parse_address(contract_hex)?;
@@ -40,7 +35,6 @@ async fn main() -> anyhow::Result<()> {
 
     let mut client = ClientBuilder::new(server_url)
         .manifest(&manifest_path)
-        .switched_query(use_switched)
         .build()?;
 
     let lane = client.get_lane(&contract);

--- a/crates/inspire-client/src/bin/main.rs
+++ b/crates/inspire-client/src/bin/main.rs
@@ -13,9 +13,9 @@ async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() < 3 {
-        eprintln!("Usage: {} <server_url> <contract_address> [slot]", args[0]);
+        eprintln!("Usage: {} <server_url> <contract_address> [slot] [--switched]", args[0]);
         eprintln!(
-            "Example: {} http://localhost:3000 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 0x00",
+            "Example: {} http://localhost:3000 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 0x00 --switched",
             args[0]
         );
         std::process::exit(1);
@@ -23,7 +23,15 @@ async fn main() -> anyhow::Result<()> {
 
     let server_url = &args[1];
     let contract_hex = &args[2];
-    let slot_hex = args.get(3).map(|s| s.as_str()).unwrap_or("0x00");
+    let mut slot_hex = "0x00";
+    let mut use_switched = false;
+    for arg in args.iter().skip(3) {
+        if arg == "--switched" {
+            use_switched = true;
+        } else {
+            slot_hex = arg;
+        }
+    }
 
     let contract = parse_address(contract_hex)?;
     let slot = parse_slot(slot_hex)?;
@@ -32,6 +40,7 @@ async fn main() -> anyhow::Result<()> {
 
     let mut client = ClientBuilder::new(server_url)
         .manifest(&manifest_path)
+        .switched_query(use_switched)
         .build()?;
 
     let lane = client.get_lane(&contract);

--- a/crates/inspire-client/src/client.rs
+++ b/crates/inspire-client/src/client.rs
@@ -262,7 +262,7 @@ impl TwoLaneClient {
             &client_state,
             &server_response,
             32,
-            InspireVariant::OnePacking,
+            InspireVariant::TwoPacking,
         )
         .map_err(|e| ClientError::InvalidResponse(e.to_string()))?;
 

--- a/crates/lane-builder/Cargo.toml
+++ b/crates/lane-builder/Cargo.toml
@@ -9,7 +9,15 @@ default = []
 # Enable dev-keys feature to allow saving secret keys (for testing/development only)
 dev-keys = []
 # Enable Reth ExEx integration for real-time lane updates
-exex = ["dep:reth-ethereum", "dep:reth-tracing", "dep:eyre", "dep:futures", "dep:clap", "dep:metrics"]
+exex = [
+    "dep:reth-ethereum",
+    "dep:reth-tracing",
+    "dep:eyre",
+    "dep:futures",
+    "dep:clap",
+    "dep:metrics",
+    "dep:reth-storage-api",
+]
 # Enable gas backfill for data-driven hot lane selection
 backfill = ["dep:alloy-provider", "dep:alloy-rpc-types", "dep:alloy-primitives", "dep:alloy-transport", "dep:futures", "dep:clap", "dep:indicatif"]
 # Enable balance extraction for ETH/USDC hot lane
@@ -26,6 +34,8 @@ state-to-pir = ["dep:clap"]
 pir-test = ["dep:clap"]
 # Enable stem index generator
 stem-index = ["dep:clap"]
+# Export UBT-ordered state.bin from vanilla reth DB
+reth-export = ["dep:reth-db", "dep:clap", "dep:indicatif"]
 
 [[bin]]
 name = "lane-builder"
@@ -34,6 +44,11 @@ path = "src/bin/main.rs"
 [[bin]]
 name = "lane-exex"
 path = "src/bin/exex.rs"
+required-features = ["exex"]
+
+[[bin]]
+name = "delta-exex"
+path = "src/bin/delta_exex.rs"
 required-features = ["exex"]
 
 [[bin]]
@@ -76,6 +91,11 @@ name = "stem-index"
 path = "src/bin/stem_index.rs"
 required-features = ["stem-index"]
 
+[[bin]]
+name = "reth-state-export"
+path = "src/bin/reth_state_export.rs"
+required-features = ["reth-export"]
+
 [dependencies]
 inspire-core = { path = "../inspire-core" }
 inspire-pir = { workspace = true }
@@ -106,6 +126,10 @@ indicatif = { workspace = true, optional = true }
 # MDBX for direct state dump
 mdbx-rs = { git = "https://github.com/igor53627/mdbx-rs", optional = true }
 color-eyre = { version = "0.6", optional = true }
+
+# Reth DB access (vanilla reth export)
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", optional = true }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", optional = true }
 
 # Bucket index builder
 tiny-keccak = { version = "2.0", features = ["keccak"], optional = true }

--- a/crates/lane-builder/src/bin/delta_exex.rs
+++ b/crates/lane-builder/src/bin/delta_exex.rs
@@ -1,0 +1,66 @@
+//! delta-exex: Run the delta exporter as a Reth Execution Extension
+//!
+//! Usage:
+//!   cargo run --bin delta-exex --features exex -- node \
+//!     --delta-output-dir ./pir-data/delta \
+//!     --delta-keep-blocks 256
+
+#![cfg(feature = "exex")]
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use eyre::Result;
+use reth_ethereum::cli::Cli;
+use reth_ethereum::node::EthereumNode;
+use reth_tracing::RethTracer;
+use reth_tracing::Tracer;
+
+use lane_builder::{delta_export_exex, DeltaExporterConfig};
+
+#[derive(Debug, Clone, Parser)]
+#[command(name = "delta-exex", about = "Delta exporter ExEx for Reth")]
+struct DeltaExExArgs {
+    /// Directory to write delta state.bin files
+    #[arg(long, env = "DELTA_OUTPUT_DIR", default_value = "./pir-data/delta")]
+    output_dir: PathBuf,
+
+    /// Number of recent blocks to keep (0 = keep all)
+    #[arg(long, env = "DELTA_KEEP_BLOCKS", default_value = "256")]
+    keep_blocks: u64,
+}
+
+fn main() -> Result<()> {
+    let _guard = RethTracer::new().init()?;
+
+    Cli::parse_args().run(|builder, _args| {
+        let exex_args = DeltaExExArgs::parse_from(std::env::args().filter(|arg| {
+            arg.starts_with("--delta") || !arg.starts_with("--")
+        }));
+
+        let config = DeltaExporterConfig {
+            output_dir: exex_args.output_dir,
+            keep_blocks: exex_args.keep_blocks,
+        };
+
+        tracing::info!(
+            output_dir = %config.output_dir.display(),
+            keep_blocks = config.keep_blocks,
+            "Starting delta exporter ExEx"
+        );
+
+        Box::pin(async move {
+            let handle = builder
+                .node(EthereumNode::default())
+                .install_exex("delta-exporter", move |ctx| {
+                    let config = config.clone();
+                    async move { delta_export_exex(ctx, config).await }
+                })
+                .launch()
+                .await?;
+
+            handle.wait_for_node_exit().await
+        })
+    })
+}
+

--- a/crates/lane-builder/src/bin/reth_state_export.rs
+++ b/crates/lane-builder/src/bin/reth_state_export.rs
@@ -1,0 +1,386 @@
+//! reth-state-export: Export storage state from a vanilla reth DB into state.bin
+//!
+//! Reads PlainStorageState from a reth MDBX database via reth-db APIs and
+//! writes a state.bin file in EIP-7864 (UBT) ordering.
+//!
+//! Usage:
+//!   cargo run --bin reth-state-export --features reth-export -- \
+//!     --db-path /path/to/reth/db \
+//!     --output ./state.bin \
+//!     --chain-id 11155111
+
+#![cfg(feature = "reth-export")]
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use indicatif::{ProgressBar, ProgressStyle};
+use inspire_core::state_format::{StateHeader, STATE_ENTRY_SIZE, STATE_HEADER_SIZE};
+use inspire_core::ubt::{compute_storage_tree_index, compute_tree_key};
+use reth_db::mdbx::DatabaseArguments;
+use reth_db::table::Table;
+use reth_db::transaction::DbTx;
+use reth_db::{open_db_read_only, tables, ClientVersion};
+use tracing::{info, warn};
+
+const RECORD_SIZE: usize = 32 + STATE_ENTRY_SIZE;
+
+type EntryBytes = [u8; STATE_ENTRY_SIZE];
+type PlainStorageKey = <tables::PlainStorageState as Table>::Key;
+type PlainStorageValue = <tables::PlainStorageState as Table>::Value;
+
+#[derive(Parser, Debug)]
+#[command(name = "reth-state-export")]
+#[command(about = "Export UBT-ordered state.bin from a vanilla reth DB")]
+struct Args {
+    /// Path to reth MDBX database directory (contains mdbx.dat)
+    #[arg(long)]
+    db_path: PathBuf,
+
+    /// Output state.bin file
+    #[arg(long, default_value = "./state.bin")]
+    output: PathBuf,
+
+    /// Chain ID to store in the header (e.g. 1 for mainnet, 11155111 for Sepolia)
+    #[arg(long, default_value = "1")]
+    chain_id: u64,
+
+    /// Number of entries per sort chunk (when sorting)
+    #[arg(long, default_value = "250000")]
+    chunk_entries: usize,
+
+    /// Temporary directory for sorted chunks (defaults to output dir)
+    #[arg(long)]
+    tmp_dir: Option<PathBuf>,
+
+    /// Log progress every N entries
+    #[arg(long, default_value = "1000000")]
+    progress_interval: u64,
+
+    /// Skip sorting (writes in DB order; not suitable for UBT lookups)
+    #[arg(long)]
+    no_sort: bool,
+
+    /// Keep temporary chunk files after merge
+    #[arg(long)]
+    keep_temp: bool,
+}
+
+#[derive(Clone)]
+struct EntryWithKey {
+    tree_key: [u8; 32],
+    entry: EntryBytes,
+}
+
+struct ChunkRecord {
+    tree_key: [u8; 32],
+    entry: EntryBytes,
+}
+
+#[derive(Eq)]
+struct HeapItem {
+    tree_key: [u8; 32],
+    entry: EntryBytes,
+    chunk_index: usize,
+}
+
+impl Ord for HeapItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.tree_key
+            .cmp(&other.tree_key)
+            .then_with(|| self.chunk_index.cmp(&other.chunk_index))
+    }
+}
+
+impl PartialOrd for HeapItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for HeapItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.tree_key == other.tree_key && self.chunk_index == other.chunk_index
+    }
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt().init();
+
+    let args = Args::parse();
+
+    info!(db_path = %args.db_path.display(), "Opening reth DB");
+    let db = open_db_read_only(&args.db_path, DatabaseArguments::new(ClientVersion::default()))
+        .with_context(|| format!("Failed to open reth DB at {}", args.db_path.display()))?;
+
+    let mut tx = db.tx()?;
+    tx.disable_long_read_transaction_safety();
+
+    let (block_number, block_hash) = latest_canonical_header(&tx)?;
+    info!(block_number, block_hash = %hex::encode(block_hash), "Using canonical head");
+
+    if args.no_sort {
+        export_unsorted(&mut tx, &args, block_number, block_hash)?;
+    } else {
+        let (total_entries, chunk_paths) = build_sorted_chunks(&mut tx, &args)?;
+        tx.commit()?;
+        write_sorted_output(&args, block_number, block_hash, total_entries, &chunk_paths)?;
+        if !args.keep_temp {
+            cleanup_chunks(&chunk_paths)?;
+        }
+        return Ok(());
+    }
+
+    tx.commit()?;
+    Ok(())
+}
+
+fn latest_canonical_header(tx: &impl DbTx) -> Result<(u64, [u8; 32])> {
+    let mut cursor = tx.cursor_read::<tables::CanonicalHeaders>()?;
+    let (block_number, block_hash) = cursor
+        .last()?
+        .ok_or_else(|| anyhow!("CanonicalHeaders table is empty"))?;
+    Ok((block_number, block_hash.0))
+}
+
+fn export_unsorted(
+    tx: &mut impl DbTx,
+    args: &Args,
+    block_number: u64,
+    block_hash: [u8; 32],
+) -> Result<()> {
+    info!(output = %args.output.display(), "Writing state.bin (unsorted)");
+
+    let file = File::create(&args.output)?;
+    let mut writer = BufWriter::new(file);
+    writer.write_all(&[0u8; STATE_HEADER_SIZE])?; // placeholder
+
+    let mut cursor = tx.cursor_dup_read::<tables::PlainStorageState>()?;
+    let mut walker = cursor.walk_dup(None, None)?;
+
+    let pb = spinner("Exporting entries (unsorted)");
+    let mut count = 0u64;
+
+    while let Some(row) = walker.next() {
+        let (address, storage_entry) = row?;
+        let entry = encode_entry(address, storage_entry)?;
+        writer.write_all(&entry)?;
+        count += 1;
+
+        if count % args.progress_interval == 0 {
+            pb.set_message(format!("{} entries", count));
+            writer.flush()?;
+        }
+    }
+
+    writer.flush()?;
+    let mut file = writer.into_inner().map_err(|e| e.into_error())?;
+    file.seek(SeekFrom::Start(0))?;
+
+    let header = StateHeader::new(count, block_number, args.chain_id, block_hash);
+    file.write_all(&header.to_bytes())?;
+    file.flush()?;
+
+    pb.finish_with_message(format!("Wrote {} entries (unsorted)", count));
+    info!(entries = count, "Export complete (unsorted)");
+
+    Ok(())
+}
+
+fn build_sorted_chunks(tx: &mut impl DbTx, args: &Args) -> Result<(u64, Vec<PathBuf>)> {
+    let tmp_dir = temp_dir(&args.output, args.tmp_dir.as_ref())?;
+    fs::create_dir_all(&tmp_dir)?;
+
+    info!(tmp_dir = %tmp_dir.display(), "Writing sorted chunks");
+
+    let mut cursor = tx.cursor_dup_read::<tables::PlainStorageState>()?;
+    let mut walker = cursor.walk_dup(None, None)?;
+
+    let pb = spinner("Sorting chunks");
+    let mut count = 0u64;
+    let mut chunk_index = 0usize;
+    let mut chunk_paths = Vec::new();
+
+    let mut buffer: Vec<EntryWithKey> = Vec::with_capacity(args.chunk_entries);
+
+    while let Some(row) = walker.next() {
+        let (address, storage_entry) = row?;
+        let (tree_key, entry) = encode_entry_with_key(address, storage_entry)?;
+        buffer.push(EntryWithKey { tree_key, entry });
+        count += 1;
+
+        if buffer.len() >= args.chunk_entries {
+            let path = flush_chunk(&mut buffer, &tmp_dir, chunk_index)?;
+            chunk_paths.push(path);
+            chunk_index += 1;
+        }
+
+        if count % args.progress_interval == 0 {
+            pb.set_message(format!("{} entries", count));
+        }
+    }
+
+    if !buffer.is_empty() {
+        let path = flush_chunk(&mut buffer, &tmp_dir, chunk_index)?;
+        chunk_paths.push(path);
+    }
+
+    pb.finish_with_message(format!("Prepared {} entries", count));
+
+    Ok((count, chunk_paths))
+}
+
+fn write_sorted_output(
+    args: &Args,
+    block_number: u64,
+    block_hash: [u8; 32],
+    total_entries: u64,
+    chunk_paths: &[PathBuf],
+) -> Result<()> {
+    info!(output = %args.output.display(), "Merging sorted chunks");
+
+    let file = File::create(&args.output)?;
+    let mut writer = BufWriter::new(file);
+    let header = StateHeader::new(total_entries, block_number, args.chain_id, block_hash);
+    writer.write_all(&header.to_bytes())?;
+
+    let mut readers: Vec<BufReader<File>> = Vec::with_capacity(chunk_paths.len());
+    for path in chunk_paths {
+        readers.push(BufReader::new(File::open(path)?));
+    }
+
+    let mut heap: BinaryHeap<std::cmp::Reverse<HeapItem>> = BinaryHeap::new();
+    for (idx, reader) in readers.iter_mut().enumerate() {
+        if let Some(record) = read_record(reader)? {
+            heap.push(std::cmp::Reverse(HeapItem {
+                tree_key: record.tree_key,
+                entry: record.entry,
+                chunk_index: idx,
+            }));
+        }
+    }
+
+    let pb = spinner("Merging chunks");
+    let mut written = 0u64;
+
+    while let Some(std::cmp::Reverse(item)) = heap.pop() {
+        writer.write_all(&item.entry)?;
+        written += 1;
+
+        if written % args.progress_interval == 0 {
+            pb.set_message(format!("{} entries", written));
+            writer.flush()?;
+        }
+
+        if let Some(record) = read_record(&mut readers[item.chunk_index])? {
+            heap.push(std::cmp::Reverse(HeapItem {
+                tree_key: record.tree_key,
+                entry: record.entry,
+                chunk_index: item.chunk_index,
+            }));
+        }
+    }
+
+    writer.flush()?;
+    pb.finish_with_message(format!("Merged {} entries", written));
+
+    if written != total_entries {
+        warn!(written, total = total_entries, "Entry count mismatch after merge");
+    }
+
+    Ok(())
+}
+
+fn encode_entry(address: PlainStorageKey, storage_entry: PlainStorageValue) -> Result<EntryBytes> {
+    let address_bytes = address.0 .0;
+    let slot_bytes: [u8; 32] = storage_entry.key.0;
+    let value_bytes: [u8; 32] = storage_entry.value.to_be_bytes();
+
+    let tree_index = compute_storage_tree_index(&slot_bytes);
+    let entry = inspire_core::state_format::StorageEntry::new(address_bytes, tree_index, value_bytes);
+    Ok(entry.to_bytes())
+}
+
+fn encode_entry_with_key(
+    address: PlainStorageKey,
+    storage_entry: PlainStorageValue,
+) -> Result<([u8; 32], EntryBytes)> {
+    let address_bytes = address.0 .0;
+    let slot_bytes: [u8; 32] = storage_entry.key.0;
+    let value_bytes: [u8; 32] = storage_entry.value.to_be_bytes();
+
+    let tree_index = compute_storage_tree_index(&slot_bytes);
+    let tree_key = compute_tree_key(&address_bytes, &tree_index);
+    let entry = inspire_core::state_format::StorageEntry::new(address_bytes, tree_index, value_bytes);
+
+    Ok((tree_key, entry.to_bytes()))
+}
+
+fn flush_chunk(buffer: &mut Vec<EntryWithKey>, dir: &Path, index: usize) -> Result<PathBuf> {
+    buffer.sort_by_key(|entry| entry.tree_key);
+
+    let path = dir.join(format!("chunk_{:05}.bin", index));
+    let file = File::create(&path)?;
+    let mut writer = BufWriter::new(file);
+
+    for entry in buffer.iter() {
+        writer.write_all(&entry.tree_key)?;
+        writer.write_all(&entry.entry)?;
+    }
+
+    writer.flush()?;
+    buffer.clear();
+
+    Ok(path)
+}
+
+fn read_record(reader: &mut BufReader<File>) -> Result<Option<ChunkRecord>> {
+    let mut buf = [0u8; RECORD_SIZE];
+    match reader.read_exact(&mut buf) {
+        Ok(()) => {
+            let mut tree_key = [0u8; 32];
+            let mut entry = [0u8; STATE_ENTRY_SIZE];
+            tree_key.copy_from_slice(&buf[..32]);
+            entry.copy_from_slice(&buf[32..]);
+            Ok(Some(ChunkRecord { tree_key, entry }))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn temp_dir(output: &Path, override_dir: Option<&PathBuf>) -> Result<PathBuf> {
+    if let Some(dir) = override_dir {
+        return Ok(dir.clone());
+    }
+
+    let base = output
+        .parent()
+        .ok_or_else(|| anyhow!("Output path has no parent directory"))?;
+    Ok(base.join("reth-export-chunks"))
+}
+
+fn cleanup_chunks(paths: &[PathBuf]) -> Result<()> {
+    for path in paths {
+        if let Err(err) = fs::remove_file(path) {
+            warn!(path = %path.display(), error = %err, "Failed to remove chunk file");
+        }
+    }
+    Ok(())
+}
+
+fn spinner(message: &str) -> ProgressBar {
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .template("[{elapsed_precise}] {spinner} {msg}")
+            .unwrap(),
+    );
+    pb.set_message(message.to_string());
+    pb
+}

--- a/crates/lane-builder/src/delta_exex.rs
+++ b/crates/lane-builder/src/delta_exex.rs
@@ -1,0 +1,204 @@
+//! Reth ExEx integration for per-block delta extraction.
+//!
+//! This module watches canonical chain updates and writes per-block delta
+//! `state.bin` files (UBT-ordered) derived from StorageChangeSets + PlainStorageState.
+
+#![cfg(feature = "exex")]
+
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use futures::TryStreamExt;
+use reth_ethereum::exex::{ExExContext, ExExNotification};
+use reth_execution_types::Chain;
+use reth_node_api::FullNodeComponents;
+use reth_storage_api::{DatabaseProviderFactory, StorageReader};
+use tracing::{info, warn};
+
+use inspire_core::state_format::{StateHeader, StorageEntry, STATE_ENTRY_SIZE};
+use inspire_core::ubt::{compute_storage_tree_index, compute_tree_key};
+
+/// Configuration for delta exporter ExEx.
+#[derive(Debug, Clone)]
+pub struct DeltaExporterConfig {
+    /// Directory to write delta state.bin files.
+    pub output_dir: PathBuf,
+    /// Number of recent blocks to keep (rolling window). 0 = keep all.
+    pub keep_blocks: u64,
+}
+
+impl Default for DeltaExporterConfig {
+    fn default() -> Self {
+        Self { output_dir: PathBuf::from("./pir-data/delta"), keep_blocks: 256 }
+    }
+}
+
+/// Initialize the delta exporter ExEx.
+pub async fn delta_export_exex<Node: FullNodeComponents>(
+    ctx: ExExContext<Node>,
+    config: DeltaExporterConfig,
+) -> Result<impl std::future::Future<Output = Result<()>>> {
+    info!(
+        output_dir = %config.output_dir.display(),
+        keep_blocks = config.keep_blocks,
+        "Initializing delta exporter ExEx"
+    );
+
+    Ok(delta_export_loop(ctx, config))
+}
+
+async fn delta_export_loop<Node: FullNodeComponents>(
+    mut ctx: ExExContext<Node>,
+    config: DeltaExporterConfig,
+) -> Result<()> {
+    while let Some(notification) = ctx.notifications.try_next().await? {
+        let chain_id = ctx.config.chain.chain().id();
+        match &notification {
+            ExExNotification::ChainCommitted { new } => {
+                export_chain_delta(ctx.provider(), &config, new, chain_id)?;
+                ctx.send_finished_height(new.tip().num_hash())?;
+            }
+            ExExNotification::ChainReorged { old, new } => {
+                delete_chain_deltas(&config.output_dir, old)?;
+                export_chain_delta(ctx.provider(), &config, new, chain_id)?;
+                ctx.send_finished_height(new.tip().num_hash())?;
+            }
+            ExExNotification::ChainReverted { old } => {
+                delete_chain_deltas(&config.output_dir, old)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn export_chain_delta<P, N>(
+    provider: &P,
+    config: &DeltaExporterConfig,
+    chain: &Chain<N>,
+    chain_id: u64,
+) -> Result<()>
+where
+    P: DatabaseProviderFactory,
+    N: reth_primitives_traits::NodePrimitives,
+{
+    fs::create_dir_all(&config.output_dir)?;
+
+    let db = provider.database_provider_ro()?;
+
+    for (block_number, block) in chain.blocks() {
+        let block_hash = block.hash();
+        let entries = collect_block_entries(&db, *block_number)?;
+        let output_path = write_block_delta(
+            &config.output_dir,
+            *block_number,
+            chain_id,
+            block_hash.0,
+            &entries,
+        )?;
+
+        info!(
+            block = *block_number,
+            entries = entries.len(),
+            path = %output_path.display(),
+            "Delta state written"
+        );
+
+        prune_old_blocks(&config.output_dir, config.keep_blocks, *block_number)?;
+    }
+
+    Ok(())
+}
+
+fn collect_block_entries<P>(
+    provider: &P,
+    block_number: u64,
+) -> Result<Vec<([u8; 32], [u8; STATE_ENTRY_SIZE])>>
+where
+    P: StorageReader,
+{
+    let changed = provider.changed_storages_with_range(block_number..=block_number)?;
+
+    if changed.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let address_keys =
+        changed
+            .iter()
+            .map(|(address, keys)| (*address, keys.iter().cloned().collect::<Vec<_>>()));
+
+    let updated = provider.plain_state_storages(address_keys)?;
+
+    let mut entries = Vec::new();
+    for (address, storage_entries) in updated {
+        let address_bytes = address.0 .0;
+        for storage_entry in storage_entries {
+            let slot_bytes: [u8; 32] = storage_entry.key.0;
+            let value_bytes: [u8; 32] = storage_entry.value.to_be_bytes();
+            let tree_index = compute_storage_tree_index(&slot_bytes);
+            let tree_key = compute_tree_key(&address_bytes, &tree_index);
+            let entry = StorageEntry::new(address_bytes, tree_index, value_bytes).to_bytes();
+            entries.push((tree_key, entry));
+        }
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(entries)
+}
+
+fn write_block_delta(
+    output_dir: &Path,
+    block_number: u64,
+    chain_id: u64,
+    block_hash: [u8; 32],
+    entries: &[([u8; 32], [u8; STATE_ENTRY_SIZE])],
+) -> Result<PathBuf> {
+    let path = output_dir.join(format!("delta_{:010}.bin", block_number));
+    let file = File::create(&path)?;
+    let mut writer = BufWriter::new(file);
+
+    let header = StateHeader::new(entries.len() as u64, block_number, chain_id, block_hash);
+    writer.write_all(&header.to_bytes())?;
+
+    for (_, entry) in entries {
+        writer.write_all(entry)?;
+    }
+
+    writer.flush()?;
+    Ok(path)
+}
+
+fn prune_old_blocks(output_dir: &Path, keep_blocks: u64, current_block: u64) -> Result<()> {
+    if keep_blocks == 0 || current_block < keep_blocks {
+        return Ok(());
+    }
+
+    let prune_block = current_block - keep_blocks;
+    let prune_path = output_dir.join(format!("delta_{:010}.bin", prune_block));
+    if prune_path.exists() {
+        if let Err(err) = fs::remove_file(&prune_path) {
+            warn!(path = %prune_path.display(), error = %err, "Failed to prune old delta file");
+        }
+    }
+
+    Ok(())
+}
+
+fn delete_chain_deltas<N>(output_dir: &Path, chain: &Chain<N>) -> Result<()>
+where
+    N: reth_primitives_traits::NodePrimitives,
+{
+    for (block_number, _block) in chain.blocks() {
+        let path = output_dir.join(format!("delta_{:010}.bin", block_number));
+        if path.exists() {
+            if let Err(err) = fs::remove_file(&path) {
+                warn!(path = %path.display(), error = %err, "Failed to remove reverted delta file");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/lane-builder/src/lib.rs
+++ b/crates/lane-builder/src/lib.rs
@@ -18,6 +18,9 @@ pub mod setup;
 #[cfg(feature = "exex")]
 pub mod exex;
 
+#[cfg(feature = "exex")]
+pub mod delta_exex;
+
 #[cfg(feature = "backfill")]
 pub mod gas_tracker;
 
@@ -32,6 +35,9 @@ pub use setup::{default_params, load_secret_key, test_params, TwoLaneSetup, TwoL
 
 #[cfg(feature = "exex")]
 pub use exex::{lane_updater_exex, LaneUpdaterConfig};
+
+#[cfg(feature = "exex")]
+pub use delta_exex::{delta_export_exex, DeltaExporterConfig};
 
 #[cfg(feature = "backfill")]
 pub use gas_tracker::{BackfillConfig, BackfillResult, GasStats, GasTracker};

--- a/crates/lane-builder/src/setup.rs
+++ b/crates/lane-builder/src/setup.rs
@@ -268,6 +268,7 @@ pub fn default_params() -> InspireParams {
     InspireParams {
         ring_dim: 2048,
         q: 1152921504606830593, // 2^60 - 2^14 + 1
+        crt_moduli: vec![1152921504606830593],
         p: 65537,               // Fermat prime F4, ensures gcd(d, p) = 1 for mod_inverse
         sigma: 6.4,
         gadget_base: 1 << 20,
@@ -281,6 +282,7 @@ pub fn test_params() -> InspireParams {
     InspireParams {
         ring_dim: 256,
         q: 1152921504606830593,
+        crt_moduli: vec![1152921504606830593],
         p: 65537, // Fermat prime F4, ensures gcd(d, p) = 1 for mod_inverse
         sigma: 6.4,
         gadget_base: 1 << 20,

--- a/examples/benchmark_seed_expansion.rs
+++ b/examples/benchmark_seed_expansion.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             InspireParams {
                 ring_dim: 256,
                 q: 1152921504606830593,
+                crt_moduli: vec![1152921504606830593],
                 p: 65537, // Fermat prime F4
                 sigma: 3.2,
                 gadget_base: 1 << 20,


### PR DESCRIPTION
## Summary
- use TwoPacking extraction in clients (seeded + packed, no switching)
- update pir-test to use seeded queries + TwoPacking
- add crt_moduli to explicit InspireParams initializers
- drop `--switched` CLI usage in inspire-client bin

## Context
Switched + OnePacking is incorrect with current params; we’re moving to InsPIRe^2 (TwoPacking) without switching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves clients to TwoPacking extraction with seeded queries and updates APIs/utilities accordingly.
> 
> - Switches `extract_with_variant` to `InspireVariant::TwoPacking` in WASM and Rust clients and test tool; `pir-test` now uses seeded queries only
> - Adds server support for switched queries with new endpoints (`/query/:lane/switched[/(binary)]`) and corresponding client methods
> - Introduces lane-builder utilities: new ExEx delta exporter (`delta-exex`) and vanilla reth DB exporter (`reth-state-export`); wires `delta_exex` module and features
> - Extends `InspireParams` initializers to include `crt_moduli` across setups and examples
> - Minor CLI tweak in `inspire-client` slot parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fab454033d2086a5d86b12b6d07174d0a94f4dc9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Switched query support enables compressed PIR queries with configurable client routing options
  * Seeded query capability provides optimized query generation and transmission paths
  * New state export utility for inspecting blockchain storage state with sorting options
  * Delta exporter tool tracks per-block state changes with configurable block retention
  * Server endpoints expanded to support switched query requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->